### PR TITLE
Wrap Koa's response emitter in a context

### DIFF
--- a/src/context-factory/context-factory.js
+++ b/src/context-factory/context-factory.js
@@ -13,6 +13,8 @@ class ContextFactory {
           'request_id',
           ctx.request.headers['x-request-id'] || uuid.v4()
         );
+        namespace.bindEmitter(ctx.req);
+        namespace.bindEmitter(ctx.res);
 
         next().then(resolve).catch(reject);
       }));


### PR DESCRIPTION
As in express, there are some Koa modules that make use of the response event emitter (koa-logger for example) and this change makes it work in these cases.